### PR TITLE
adding pubsub configuration

### DIFF
--- a/src/firebase_emulator_admin_test_app.ts
+++ b/src/firebase_emulator_admin_test_app.ts
@@ -30,6 +30,7 @@ export class GPFirebaseEmulatorAdminTestApp {
     private _authEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
     private _firestoreEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
     private _storageEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
+    private _pubsubEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
 
     private firebaseApp?: admin.app.App;
 
@@ -55,6 +56,7 @@ export class GPFirebaseEmulatorAdminTestApp {
             this._firestoreEmulatorHostConfig = emulatorConfig.firestoreEmulatorHostConfig;
             // this.functionsEmulatorHostConfig = emulatorConfig.functionsEmulatorHostConfig;
             this._storageEmulatorHostConfig = emulatorConfig.storageEmulatorHostConfig;
+            this._pubsubEmulatorHostConfig = emulatorConfig.pubsubEmulatorHostConfig;
 
             if (this._authEmulatorHostConfig || this._firestoreEmulatorHostConfig || this._storageEmulatorHostConfig) {
                 process.env.GCLOUD_PROJECT = this._projectId;
@@ -68,6 +70,10 @@ export class GPFirebaseEmulatorAdminTestApp {
 
                 if (this._storageEmulatorHostConfig) {
                     process.env.FIREBASE_STORAGE_EMULATOR_HOST = `${this._storageEmulatorHostConfig.hostname}:${this._storageEmulatorHostConfig.port}`;
+                }
+
+                if (this._pubsubEmulatorHostConfig) {
+                    process.env.FIREBASE_PUBSUB_EMULATOR_HOST = `${this._pubsubEmulatorHostConfig.hostname}:${this._pubsubEmulatorHostConfig.port}`;
                 }
 
                 this.firebaseApp = admin.initializeApp({ projectId: this._projectId, storageBucket: this._storageBucket }, 'app-' + new Date().getTime() + '-' + Math.random());

--- a/src/models/firebase_emulator_config.model.ts
+++ b/src/models/firebase_emulator_config.model.ts
@@ -26,6 +26,7 @@ export class GPFirebaseEmulatorConfig {
     _firestoreEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
     _functionsEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
     _storageEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
+    _pubsubEmulatorHostConfig?: GPFirebaseEmulatorHostConfig;
 
     /**
      * Class constructor using provided config for each emulator components
@@ -33,12 +34,20 @@ export class GPFirebaseEmulatorConfig {
      * @param firestoreEmulatorConfig The Cloud Firestore emulator config
      * @param functionsEmulatorConfig The Cloud Functions emulator config
      * @param storageEmulatorConfig The Cloud Storage emulator config
+     * @param pubsubEmulatorConfig The Cloud PubSub emulator config
      */
-    private constructor(authEmulatorConfig?: GPFirebaseEmulatorHostConfig, firestoreEmulatorConfig?: GPFirebaseEmulatorHostConfig, functionsEmulatorConfig?: GPFirebaseEmulatorHostConfig, storageEmulatorConfig?: GPFirebaseEmulatorHostConfig) {
+    private constructor(
+        authEmulatorConfig?: GPFirebaseEmulatorHostConfig,
+        firestoreEmulatorConfig?: GPFirebaseEmulatorHostConfig,
+        functionsEmulatorConfig?: GPFirebaseEmulatorHostConfig,
+        storageEmulatorConfig?: GPFirebaseEmulatorHostConfig,
+        pubsubEmulatorConfig?: GPFirebaseEmulatorHostConfig
+    ) {
         this._authEmulatorHostConfig = authEmulatorConfig;
         this._firestoreEmulatorHostConfig = firestoreEmulatorConfig;
         this._functionsEmulatorHostConfig = functionsEmulatorConfig;
         this._storageEmulatorHostConfig = storageEmulatorConfig;
+        this._pubsubEmulatorHostConfig = pubsubEmulatorConfig;
     }
 
     /**
@@ -47,8 +56,8 @@ export class GPFirebaseEmulatorConfig {
      * @param hubHostname The Hub hostname (default: localhost)
      * @param hubPort The Hub port (default: 4400)
      * @returns The Firabase emulator config for each activated components
-     *          (limitted to Auth, Cloud Firestore, Cloud Functions and Cloud
-     *          Storage)
+     *          (limitted to Auth, Cloud Firestore, Cloud Functions, Cloud
+     *          Storage, and Cloud PubSub)
      */
     public static async fromHubApi(hubHostname?: string, hubPort?: number) {
         const intHubHostname = hubHostname || 'localhost';
@@ -61,7 +70,8 @@ export class GPFirebaseEmulatorConfig {
             emulatorConfig.auth ? { hostname: emulatorConfig.auth.host || 'localhost', port: emulatorConfig.auth.port || 9099 } : undefined,
             emulatorConfig.firestore ? { hostname: emulatorConfig.firestore.host || 'localhost', port: emulatorConfig.firestore.port || 8080 } : undefined,
             emulatorConfig.functions ? { hostname: emulatorConfig.functions.host || 'localhost', port: emulatorConfig.functions.port || 5001 } : undefined,
-            emulatorConfig.storage ? { hostname: emulatorConfig.storage.host || 'localhost', port: emulatorConfig.storage.port || 9199 } : undefined
+            emulatorConfig.storage ? { hostname: emulatorConfig.storage.host || 'localhost', port: emulatorConfig.storage.port || 9199 } : undefined,
+            emulatorConfig.pubsub ? { hostname: emulatorConfig.pubsub.host || 'localhost', port: emulatorConfig.pubsub.port || 9299 } : undefined
         );
     }
 
@@ -91,5 +101,12 @@ export class GPFirebaseEmulatorConfig {
      */
     public get storageEmulatorHostConfig() {
         return this._storageEmulatorHostConfig;
+    }
+
+    /**
+     * Return the configuration of the Cloud PubSub emulator
+     */
+    public get pubsubEmulatorHostConfig() {
+        return this._pubsubEmulatorHostConfig;
     }
 }


### PR DESCRIPTION
i only added the configs for `GPFirebaseEmulatorAdminTestApp`. And I randomly choose port 9299 as default port, it seemed to be the schema (9099, 9199...). I suppose it's all is needed ?

- i didn't expose the pubsub port 18004 in devcontainer, dockerfile and docker compose, i don't think i need to do it ?
- i didn't add configuration for pubsub in `GPFirebaseEmulatorTestApp` because i think it's not what we need, but maybe i'm wrong ?